### PR TITLE
Fix ProfileService IsActive incorrect type

### DIFF
--- a/profileservice/globals.d.ts
+++ b/profileservice/globals.d.ts
@@ -150,7 +150,7 @@ export interface ViewProfile<DataType extends Object> {
 	/**
 	 * Returns `true` while the profile is session-locked and saving of changes to Profile.Data is guaranteed.
 	 */
-	IsActive: boolean;
+	IsActive(): boolean;
 	/**
 	 * Equivalent of `Profile.MetaData.MetaTags.get(tagName)`.
 	 * @see `Profile.SetMetaTag` for more info.


### PR DESCRIPTION
ProfileService's Profile.IsActive method has an incorrect type of `boolean`. It should be `() => boolean`