### PR TITLE
feat(RotatedRegion3): expose RR3 to RR3 hit test

### DIFF
--- a/RotatedRegion3/index.d.ts
+++ b/RotatedRegion3/index.d.ts
@@ -84,6 +84,13 @@ declare class RotatedRegion3 {
 	CastPoint(point: Vector3): boolean
 
 	/**
+	 * Checks if a RotatedRegion3 is within the RotatedRegion3 object
+	 * @param r3 the RotatedRegion3 to check is within the RotatedRegion3 object
+	 * @returns true or false if the RotatedRegion3 is within the RotatedRegion3 object
+	 */
+	CastRotatedRegion3(r3: RotatedRegion3): boolean
+
+	/**
 	 * Checks if a part is within the RotatedRegion3 object
 	 * @param part the part to check is within the RotatedRegion3 object
 	 * @returns true or false if the point is within the RotatedRegion3 object

--- a/RotatedRegion3/init.lua
+++ b/RotatedRegion3/init.lua
@@ -175,7 +175,7 @@ function RotatedRegion3:CastRotatedRegion3(r3)
 end
 function RotatedRegion3:CastPart(part)
 	local r3 = RotatedRegion3.FromPart(part)
-	return RotatedRegion3:CastRegion3(r3);
+	return RotatedRegion3:CastRotatedRegion3(r3);
 end
 function RotatedRegion3:FindPartsInRegion3(ignore, maxParts)
 	local found = {}

--- a/RotatedRegion3/init.lua
+++ b/RotatedRegion3/init.lua
@@ -29,8 +29,10 @@ Constructors:
 Methods:
 	RotatedRegion3:CastPoint(Vector3 point)
 		> returns true or false if the point is within the RotatedRegion3 object
+	RotatedRegion3:CastRotatedRegion3(RotatedRegion3 r3)
+		> returns true or false if the RotatedRegion3 is within the RotatedRegion3 object
 	RotatedRegion3:CastPart(BasePart part)
-		> returns true or false if the part is withing the RotatedRegion3 object
+		> returns true or false if the part is within the RotatedRegion3 object
 	RotatedRegion3:FindPartsInRegion3(Instance ignore, Integer maxParts)
 		> returns array of parts in the RotatedRegion3 object
 		> will return a maximum number of parts in array [maxParts] the default is 20
@@ -167,10 +169,13 @@ function RotatedRegion3:CastPoint(point)
 	local gjk = GJK.new(self.Set, {point}, self.Centroid, point, self.Support, Supports.PointCloud)
 	return gjk:IsColliding()
 end
-function RotatedRegion3:CastPart(part)
-	local r3 = RotatedRegion3.FromPart(part)
+function RotatedRegion3:CastRotatedRegion3(r3)
 	local gjk = GJK.new(self.Set, r3.Set, self.Centroid, r3.Centroid, self.Support, r3.Support)
 	return gjk:IsColliding()
+end
+function RotatedRegion3:CastPart(part)
+	local r3 = RotatedRegion3.FromPart(part)
+	return RotatedRegion3:CastRegion3(r3);
 end
 function RotatedRegion3:FindPartsInRegion3(ignore, maxParts)
 	local found = {}


### PR DESCRIPTION
My application uses virtualization to build a "theory" about where Parts will be, without physically positioning the Model geometry there.

Therefore there is not an actual part in the hit tested region yet.  But, it's RR3 is computed in advance.

This small change will allow me to check if a RR3 is within another RR3 without any meshes being materialized.