### PR TITLE
Add stripTrailingZeroes setting

### DIFF
--- a/abbreviate/src/index.d.ts
+++ b/abbreviate/src/index.d.ts
@@ -6,6 +6,7 @@ declare class abbreviator {
 	 */
 	setSetting(settingName: "suffixTable", settingValue: Array<string>): void;
 	setSetting(settingName: "decimalPlaces", settingValue: number): void;
+	setSetting(settingName: "stripTrailingZeroes", settingValue: boolean): void;
 
 	/**
 	 * Separates a number by the thousands of places with commas.

--- a/abbreviate/src/init.lua
+++ b/abbreviate/src/init.lua
@@ -61,6 +61,7 @@ return function()
 	return {
 		_suffixTable = DEFAULT_SUFFIX_TABLE,
 		_decimalPlaces = 2,
+		_stripTrailingZeroes = false,
 
 		setSetting = setSetting,
 		numberToString = numberToString,

--- a/abbreviate/src/numberToString.lua
+++ b/abbreviate/src/numberToString.lua
@@ -1,15 +1,41 @@
+local function round(number, decimalPlaces, roundDown)
+	number = number * 10^decimalPlaces
+	if roundDown then
+		return math.floor(number) / 10^decimalPlaces
+	else
+		number = tonumber(tostring(number))
+		-- cast to string and back to number to prevent floating point errors
+		--[[ e.g.:
+			local number = 1005 / 10^3 * 10^2 + 0.5 -- 101
+			print(number, math.floor(number))
+			> 101 100
+
+			local number = 1005 / 10^3 * 10^2 + 0.5 -- 101
+			number = tonumber(tostring(number))
+			print(number, math.floor(number))
+			> 101 101
+		]]
+		return math.floor(number + 0.5) / 10^decimalPlaces
+	end
+end
+
 function numberToString(self, number, roundDown)
 	if type(number) ~= "number" then
 		error('numberToString invalid parameter #1, expected number, got "nil"', 2)
 	end
 
-	if number < 1000 and number > -1000 then
-		-- special case: we must manually abbreviate numbers between -1000 and 1000
-		return ("%."..self._decimalPlaces.."f"):format(number)
-	end
-
 	if roundDown == nil then
 		roundDown = true
+	end
+
+	if number < 1000 and number > -1000 then
+		-- special case: we must manually abbreviate numbers between -1000 and 1000
+		if not self._stripTrailingZeroes then
+			return ("%."..self._decimalPlaces.."f"):format(number)
+		else
+			number = round(number, self._decimalPlaces)
+			return tostring(number)
+		end
 	end
 
 	local negative = number < 0
@@ -20,18 +46,18 @@ function numberToString(self, number, roundDown)
 		local size = 10 ^ (index * 3)
 
 		if size <= number then
-			if roundDown then
-				number = math.floor(number * 10^self._decimalPlaces / size) / 10^self._decimalPlaces
-			else
-				number = math.floor((number * 10^self._decimalPlaces / size) + 0.5) / 10^self._decimalPlaces
-			end
+			number = round(number / size, self._decimalPlaces, roundDown)
 
 			if number == 1000 and index < #self._suffixTable[index] then
 				number = 1
 				unit = self._suffixTable[index][index + 1]
 			end
 
-			number = ("%."..self._decimalPlaces.."f"):format(number) .. unit
+			if not self._stripTrailingZeroes then
+				number = ("%."..self._decimalPlaces.."f"):format(number)
+			end
+
+			number = number .. unit
 			break
 		end
 	end

--- a/abbreviate/src/setSetting.lua
+++ b/abbreviate/src/setSetting.lua
@@ -1,13 +1,13 @@
 function setSetting(self, settingName, settingValue)
-	if not (settingName and settingValue and type(settingName) == 'string') then
+	if not (settingName and settingValue ~= nil and type(settingName) == 'string') then
 		error('setSetting had invalid parameters.\nP1 - settingName: string\nP2 - settingValue: unknown', 2)
 	end
 	local realSetting = '_' .. settingName
 
-	if self[realSetting] and type(self[realSetting]) ~= 'function' then
+	if self[realSetting] ~= nil and type(self[realSetting]) ~= 'function' then
 		self[realSetting] = settingValue
 	else
-		if self[realSetting] then
+		if self[realSetting] ~= nil then
 			error('Attempt to index setting ' ..settingName..' which is not an editable field.');
 		else
 			error('Attempt to index setting ' ..settingName..' which is not a valid setting!');

--- a/abbreviate/src/tests.spec.lua
+++ b/abbreviate/src/tests.spec.lua
@@ -13,6 +13,7 @@ return function()
 		it("should have settings", function()
 			expect(abbreviate._suffixTable).to.be.a("table")
 			expect(abbreviate._decimalPlaces).to.be.a("number")
+			expect(abbreviate._stripTrailingZeroes).to.be.a("boolean")
 		end)
 
 		it("should allow changable decimal places", function()
@@ -29,6 +30,13 @@ return function()
 				abbreviate:setSetting("suffixTable", newSuffixTable)
 			end).to.never.throw()
 			expect(abbreviate._suffixTable).to.equal(newSuffixTable)
+		end)
+
+		it("should allow changable strip trailing zeroes", function()
+			expect(function()
+				abbreviate:setSetting("stripTrailingZeroes", true)
+			end).to.never.throw()
+			expect(abbreviate._stripTrailingZeroes).to.equal(true)
 		end)
 	end)
 
@@ -69,6 +77,19 @@ return function()
 			-- test roundDown
 			expect(abbreviate:numberToString(1005, false)).to.equal("1.01k")
 			expect(abbreviate:numberToString(1005)).to.equal("1.00k")
+		end)
+
+		it("should work with stripTrailingZeroes set to true", function()
+			abbreviate:setSetting("stripTrailingZeroes", true)
+
+			expect(abbreviate:numberToString(0)).to.equal("0")
+			expect(abbreviate:numberToString(0.01)).to.equal("0.01")
+			expect(abbreviate:numberToString(0.1)).to.equal("0.1")
+			expect(abbreviate:numberToString(0.12)).to.equal("0.12")
+
+			expect(abbreviate:numberToString(1000)).to.equal("1k")
+			expect(abbreviate:numberToString(1200)).to.equal("1.2k")
+			expect(abbreviate:numberToString(1230)).to.equal("1.23k")
 		end)
 	end)
 


### PR DESCRIPTION
```ts
abbreviate.setSetting("stripTrailingZeroes", true);
print(abbreviate.numberToString(0)) -- 0
print(abbreviate.numberToString(1000)) -- 1k
print(abbreviate.numberToString(1200)) -- 1.2k
print(abbreviate.numbersToSortedString([0, 1000, 1200])) -- ["0", "1k", "1.2k"]

abbreviate.setSetting("stripTrailingZeroes", false);
print(abbreviate.numberToString(0)) -- 0.00
print(abbreviate.numberToString(1000)) -- 1.00k
print(abbreviate.numberToString(1200)) -- 1.20k
print(abbreviate.numbersToSortedString([0, 1000, 1200])) -- ["0.00", "1.00k", "1.20k"]
```

stripTrailingZeroes setting is false by default.

I had to fix setSetting incorrectly checking the truthy value instead of nil since stripTrailingZeroes is a boolean setting.

I added unit tests as well, they were actually pretty useful! Although, numbersToSortedString didn't have any unit tests. I ended up having to test that manually.

~~Also: I benchmarked it and stripTrailingZeroes = true is x2 faster than false!~~
EDIT: I miscalculated, stripTrailingZeroes = true is 10% faster than false