### PR TITLE
Updated Janitor to 1.1.2

### DIFF
--- a/janitor/README.md
+++ b/janitor/README.md
@@ -51,12 +51,13 @@ Obliterator.Cleanup();
 ### Unreleased Changes
 - Fixed link to Janitor repository in README.md
 
-### 1.0.8
+### 1.1.2
 - Fixed major bug where destroyed Janitors added to a Janitor do not clean up nicely. See [official release page](https://github.com/howmanysmall/Janitor/releases/tag/1.1.2) for example code.
 - Reduced the size of Scheduler.
 - Added `__tostring` to `IndicesReference`.
 - Added safety check to `AddPromise`.
 - Added `ClassName` to Janitor object.
+- Changed version to match the official release.
 
 ### 1.0.7
 - Removed the usage of global state.

--- a/janitor/README.md
+++ b/janitor/README.md
@@ -48,6 +48,7 @@ Obliterator.Cleanup();
 ```
 
 ## Changelog
+### Unreleased Changes
 
 ### 1.1.2
 - Fixed major bug where destroyed Janitors added to a Janitor do not clean up nicely. See [official release page](https://github.com/howmanysmall/Janitor/releases/tag/1.1.2) for example code.

--- a/janitor/README.md
+++ b/janitor/README.md
@@ -48,8 +48,6 @@ Obliterator.Cleanup();
 ```
 
 ## Changelog
-### Unreleased Changes
-- Fixed link to Janitor repository in README.md
 
 ### 1.1.2
 - Fixed major bug where destroyed Janitors added to a Janitor do not clean up nicely. See [official release page](https://github.com/howmanysmall/Janitor/releases/tag/1.1.2) for example code.

--- a/janitor/README.md
+++ b/janitor/README.md
@@ -58,6 +58,7 @@ Obliterator.Cleanup();
 - Added safety check to `AddPromise`.
 - Added `ClassName` to Janitor object.
 - Changed version to match the official release.
+- Fixed link to Janitor repository in README.md
 
 ### 1.0.7
 - Removed the usage of global state.

--- a/janitor/README.md
+++ b/janitor/README.md
@@ -51,6 +51,13 @@ Obliterator.Cleanup();
 ### Unreleased Changes
 - Fixed link to Janitor repository in README.md
 
+### 1.0.8
+- Fixed major bug where destroyed Janitors added to a Janitor do not clean up nicely. See [official release page](https://github.com/howmanysmall/Janitor/releases/tag/1.1.2) for example code.
+- Reduced the size of Scheduler.
+- Added `__tostring` to `IndicesReference`.
+- Added safety check to `AddPromise`.
+- Added `ClassName` to Janitor object.
+
 ### 1.0.7
 - Removed the usage of global state.
 - Optimized the `LinkToInstances` function.

--- a/janitor/package.json
+++ b/janitor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rbxts/janitor",
-	"version": "1.0.8",
+	"version": "1.1.2",
 	"description": "A port of pobammer's janitor module.",
 	"main": "src/init.lua",
 	"types": "index.d.ts",

--- a/janitor/package.json
+++ b/janitor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rbxts/janitor",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"description": "A port of pobammer's janitor module.",
 	"main": "src/init.lua",
 	"types": "index.d.ts",

--- a/janitor/src/Scheduler.lua
+++ b/janitor/src/Scheduler.lua
@@ -8,7 +8,9 @@ local RunService = game:GetService("RunService")
 local Heartbeat = RunService.Heartbeat
 local TimeFunction = RunService:IsRunning() and time or os.clock
 
-local Scheduler = {}
+local Scheduler = {
+	TimeFunction = TimeFunction;
+}
 
 local Queue = {}
 local CurrentLength = 0
@@ -152,42 +154,6 @@ function Scheduler.Wait(Seconds)
 end
 
 --[[**
-	Significantly simpler reimplementation of `wait`. This works the exact same, just a bit worse performing.
-	@param [number?] Seconds The amount of time to yield for.
-	@returns [number] The actual time yielded.
-**--]]
-function Scheduler.Wait2(Seconds)
-	Seconds = math.max(Seconds or 0.03, 0.029)
-	local TimeRemaining = Seconds
-
-	while TimeRemaining > 0 do
-		TimeRemaining -= Heartbeat:Wait()
-	end
-
-	return Seconds - TimeRemaining
-end
-
--- @source https://devforum.roblox.com/t/psa-you-can-get-errors-and-stack-traces-from-coroutines/455510/2
-local function Finish(Thread, Success, ...)
-	if not Success then
-		warn(debug.traceback(Thread, tostring((...))))
-	end
-
-	return Success, ...
-end
-
---[[**
-	Spawns the passed function immediately using coroutines. This keeps the traceback as well, and warns if the function errors.
-	@param [function] Function The function you are calling.
-	@param [...?] ... The optional arguments to call the function with.
-	@returns [(boolean, ...)] Whether or not the call was successful and the returned values.
-**--]]
-function Scheduler.Spawn(Function, ...)
-	local Thread = coroutine.create(Function)
-	return Finish(Thread, coroutine.resume(Thread, ...))
-end
-
---[[**
 	Spawns the passed function immediately using a BindableEvent. This keeps the traceback as well, and will throw an error if the function errors.
 	@param [function] Function The function you are calling.
 	@param [...?] ... The optional arguments to call the function with.
@@ -202,74 +168,6 @@ function Scheduler.FastSpawn(Function, ...)
 
 	BindableEvent:Fire()
 	BindableEvent:Destroy()
-end
-
---[[**
-	Spawns the passed function with a delay using Heartbeat. This keeps the traceback as well, and will throw an error if the function errors.
-	@param [function] Function The function you are calling.
-	@param [...?] ... The optional arguments to call the function with.
-	@returns [void]
-**--]]
-function Scheduler.SpawnDelayed(Function, ...)
-	local Length = select("#", ...)
-	if Length > 0 then
-		local Arguments = {...}
-		local HeartbeatConnection
-
-		HeartbeatConnection = Heartbeat:Connect(function()
-			HeartbeatConnection:Disconnect()
-			Function(table.unpack(Arguments, 1, Length))
-		end)
-	else
-		local HeartbeatConnection
-		HeartbeatConnection = Heartbeat:Connect(function()
-			HeartbeatConnection:Disconnect()
-			Function()
-		end)
-	end
-end
-
---[[**
-	A recreation of `spawn`, delay and all. This should in theory run better than the original spawn, as well as not using a garbage legacy scheduler. Use it Michal.
-	@param [function] Function The function you are calling.
-	@param [...?] ... The optional arguments to call the function with.
-	@returns [void]
-**--]]
-function Scheduler.NewSpawn(Function, ...)
-	local StartTime = TimeFunction()
-	local EndTime = StartTime + 0.03
-	local Length = select("#", ...)
-
-	if Connection == nil then -- first is nil when connection is nil
-		Connection = Heartbeat:Connect(HeartbeatStep)
-	end
-
-	local Node = {
-		Function = Function;
-		StartTime = StartTime;
-		EndTime = EndTime;
-		Arguments = Length > 0 and {Length + 1, ...};
-	}
-
-	local TargetIndex = CurrentLength + 1
-	CurrentLength = TargetIndex
-
-	while true do
-		local ParentIndex = (TargetIndex - TargetIndex % 2) / 2
-		if ParentIndex < 1 then
-			break
-		end
-
-		local ParentNode = Queue[ParentIndex]
-		if ParentNode.EndTime < Node.EndTime then
-			break
-		end
-
-		Queue[TargetIndex] = ParentNode
-		TargetIndex = ParentIndex
-	end
-
-	Queue[TargetIndex] = Node
 end
 
 return Scheduler


### PR DESCRIPTION
Fixed the major bug you pointed out about not handling destroyed Janitors very nicely.

*Official changelog:*

- Fixed major bug where destroyed Janitors added to a Janitor do not clean up nicely. See [official release page](https://github.com/howmanysmall/Janitor/releases/tag/1.1.2) for example code.
- Reduced the size of Scheduler.
- Added `__tostring` to `IndicesReference`.
- Added safety check to `AddPromise`.
- Added `ClassName` to Janitor object.
- Made version numbers match.