### PR TITLE
tableutil.Shuffle has the wrong return type

### DIFF
--- a/tableutil/index.d.ts
+++ b/tableutil/index.d.ts
@@ -30,7 +30,7 @@ declare namespace tableutil {
 	 * Shuffles the array. Internally, this is using the Fisher-Yates algorithm to shuffle around the items.
 	 * @param tbl The array to shuffle
 	 */
-	export function Shuffle<T>(tbl: Array<T>): Array<T>;
+	export function Shuffle(tbl: object): void;
 
 	/**
 	 * Returns `true` if the table is empty.


### PR DESCRIPTION
it seems like tableutil.Shuffle doesn't return anything, but mutates the original array
```lua
local function Shuffle(tbl)
	assert(type(tbl) == "table", "First argument must be a table")
	local rng = Random.new()
	for i = #tbl, 2, -1 do
		local j = rng:NextInteger(1, i)
		tbl[i], tbl[j] = tbl[j], tbl[i]
	end
end
```