### PR TITLE
Fixed Janitor 'Is' Typing

### DIFF
--- a/janitor/index.d.ts
+++ b/janitor/index.d.ts
@@ -96,5 +96,5 @@ export class Janitor<U extends object | void = void> {
 	 * @param object The object you are checking.
 	 * @returns Whether or not the object is a Janitor.
 	 */
-	public static Is<T extends object>(object: unknown): object is Janitor<T>;
+	public static Is: <T extends object>(object: unknown) => object is Janitor<T>;
 }


### PR DESCRIPTION
The current typing is compiling to `Janitor:Is`, whereas it should compile to `Janitor.Is`. This fixes this.