### PR TITLE
Fix component types

### DIFF
--- a/virtualized-list/CHANGELOG.md
+++ b/virtualized-list/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix component types to allow for functional components (#30)
+
 ## v1.3.2 (October 12, 2023)
 
 - Initial release to upstream https://github.com/jsdotlua/virtualized-list-lua/tree/b5d610b6e8a7a39192a43b6a12272757c4356d10

--- a/virtualized-list/src/typings/flatList.d.ts
+++ b/virtualized-list/src/typings/flatList.d.ts
@@ -1,24 +1,24 @@
 import Roact from "@rbxts/roact";
-import { ListRenderItem, ViewToken, VirtualizedListProps } from "./virtualizedList";
+import { ScrollViewComponent } from "./scrollView";
 import { StyleProp, ViewStyle } from "./unimplemented";
 import { View } from "./view";
-import { ScrollViewComponent } from "./scrollView";
+import { ListRenderItem, ViewToken, VirtualizedListProps } from "./virtualizedList";
 
 export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered in between each item, but not at the top or bottom
      */
-    ItemSeparatorComponent?: Roact.Component<any> | null | undefined;
+    ItemSeparatorComponent?: Roact.ComponentType<any> | null | undefined;
 
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: Roact.Component<any> | Roact.Element | null | undefined;
+    ListEmptyComponent?: Roact.ComponentType<any> | Roact.Element | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: Roact.Component<any> | Roact.Element | null | undefined;
+    ListFooterComponent?: Roact.ComponentType<any> | Roact.Element | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -28,7 +28,7 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: Roact.Component<any> | Roact.Element | null | undefined;
+    ListHeaderComponent?: Roact.ComponentType<any> | Roact.Element | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent

--- a/virtualized-list/src/typings/scrollView.d.ts
+++ b/virtualized-list/src/typings/scrollView.d.ts
@@ -1,7 +1,6 @@
 import Roact from "@rbxts/roact";
 import { Constructor } from "./shared";
-import { ScrollResponderEvent } from "./unimplemented";
-import { ColorValue, ScrollEvent, StyleProp, ViewStyle } from "./unimplemented";
+import { ColorValue, ScrollEvent, ScrollResponderEvent, StyleProp, ViewStyle } from "./unimplemented";
 import { Touchable, ViewProps } from "./view";
 
 export interface Insets {
@@ -518,7 +517,7 @@ export interface ScrollViewProps extends ViewProps, ScrollViewPropsIOS, ScrollVi
      * transforms, for example, when you want your list to have an animated and hidable header.
      * If component have not been provided, the default ScrollViewStickyHeader component will be used.
      */
-    StickyHeaderComponent?: Roact.Component<any> | undefined; // OverHash deviation: originally `React.ComponentType<any>`
+    StickyHeaderComponent?: Roact.ComponentType<any> | undefined; // OverHash deviation: originally `React.ComponentType<any>`
 }
 
 declare class ScrollViewComponent extends Roact.Component<ScrollViewProps> {

--- a/virtualized-list/src/typings/sectionList.d.ts
+++ b/virtualized-list/src/typings/sectionList.d.ts
@@ -26,7 +26,7 @@ export interface SectionBase<ItemT, SectionT = DefaultSectionT> {
 
     renderItem?: SectionListRenderItem<ItemT, SectionT> | undefined;
 
-    ItemSeparatorComponent?: Roact.Component<any> | null | undefined;
+    ItemSeparatorComponent?: Roact.ComponentType<any> | null | undefined;
 
     keyExtractor?: ((item: ItemT, index: number) => string) | undefined;
 }
@@ -49,17 +49,17 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered in between adjacent Items within each section.
      */
-    ItemSeparatorComponent?: Roact.Component<any> | null | undefined;
+    ItemSeparatorComponent?: Roact.ComponentType<any> | null | undefined;
 
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: Roact.Component<any> | Roact.Element | null | undefined;
+    ListEmptyComponent?: Roact.ComponentType<any> | Roact.Element | null | undefined;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: Roact.Component<any> | Roact.Element | null | undefined;
+    ListFooterComponent?: Roact.ComponentType<any> | Roact.Element | null | undefined;
 
     /**
      * Styling for internal View for ListFooterComponent
@@ -69,7 +69,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: Roact.Component<any> | Roact.Element | null | undefined;
+    ListHeaderComponent?: Roact.ComponentType<any> | Roact.Element | null | undefined;
 
     /**
      * Styling for internal View for ListHeaderComponent
@@ -79,7 +79,7 @@ export interface SectionListProps<ItemT, SectionT = DefaultSectionT>
     /**
      * Rendered in between each section.
      */
-    SectionSeparatorComponent?: Roact.Component<any> | Roact.Element | null | undefined;
+    SectionSeparatorComponent?: Roact.ComponentType<any> | Roact.Element | null | undefined;
 
     /**
      * A marker property for telling the list to re-render (since it implements PureComponent).

--- a/virtualized-list/src/typings/virtualizedList.d.ts
+++ b/virtualized-list/src/typings/virtualizedList.d.ts
@@ -74,19 +74,19 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT> extends ScrollView
      * Rendered when the list is empty. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListEmptyComponent?: Roact.Component<any> | Roact.Element | null | undefined;
+    ListEmptyComponent?: Roact.ComponentType<any> | Roact.Element | null | undefined;
 
     /**
      * Rendered at the bottom of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListFooterComponent?: Roact.Component<any> | Roact.Element | null | undefined;
+    ListFooterComponent?: Roact.ComponentType<any> | Roact.Element | null | undefined;
 
     /**
      * Rendered at the top of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListHeaderComponent?: Roact.Component<any> | Roact.Element | null | undefined;
+    ListHeaderComponent?: Roact.ComponentType<any> | Roact.Element | null | undefined;
 
     /**
      * The default accessor functions assume this is an Array<{key: string}> but you can override


### PR DESCRIPTION
This PR fixes component types to use Roact.ComponentType<T> instead of Roact.Component<T> so that it allows use of functional components.