### PR TITLE
Update to v1.18.3

### DIFF
--- a/janitor/index.d.ts
+++ b/janitor/index.d.ts
@@ -10,9 +10,17 @@ export class Janitor<U extends object | void = void> {
 	public readonly CurrentlyCleaning: boolean;
 
 	/**
-	 * Whether or not you want to suppress the re-destroying of instances. Default is false, which is the original behavior.
+	 * Whether or not you want to suppress the re-destroying of instances.
+	 * Default is `false`, which is the original behavior.
 	 */
-	public SupressInstanceReDestroy: boolean;
+	public SuppressInstanceReDestroy: boolean;
+
+	/**
+	 * Whether or not to use the unsafe fast defer function for cleaning up
+	 * threads. This might be able to throw, so be careful. If you're getting
+	 * any thread related errors, chances are it is this.
+	 */
+	public UnsafeThreadCleanup: boolean;
 
 	/**
 	 * Instantiates a new Janitor object.
@@ -20,111 +28,188 @@ export class Janitor<U extends object | void = void> {
 	public constructor();
 
 	/**
-	 * Adds an `Object` to Janitor for later cleanup, where `MethodName` is the key of the method within `Object` which should be called at cleanup time.
+	 * Adds an {@linkcode object} to Janitor for later cleanup, where
+	 * {@linkcode methodName} is the key of the method within {@linkcode object}
+	 * which should be called at cleanup time.
 	 *
-	 * If the `MethodName` is `true` the `Object` itself will be called instead.
+	 * If the {@linkcode methodName} is `true` the {@linkcode object} itself
+	 * will be either called if it is a function or have `task.cancel` called on
+	 * it if it is a thread.
 	 *
-	 * If passed an index it will occupy a namespace which can be `Remove()`d or overwritten. Returns the `Object`.
+	 * If passed an {@linkcode index} it will occupy a namespace which can be
+	 * {@linkcode Janitor.Remove}'d or overwritten. Returns the
+	 * {@linkcode object}.
+	 * 
+	 * @example
+	 * import { Workspace, TweenService } from "@rbxts/services";
+	 * import { Janitor } from "@rbxts/janitor";
+	 * 
+	 * const obliterator = new Janitor<{ CurrentTween: Tween }>();
+	 * const part = Workspace.FindFirstChild("Part") as Part;
+	 * 
+	 * // Queue the part to be Destroyed at Cleanup time
+	 * obliterator.Add(part, "Destroy");
+	 * 
+	 * // Queue function to be called with `true` methodName
+	 * obliterator.Add(print, true);
+	 * 
+	 * // Close a thread.
+	 * obliterator.Add(task.defer(() => {
+	 * 		while (true) {
+	 * 			 print("Running!");
+	 * 			task.wait(0.5);
+	 * 		}
+	 * }), true);
+	 * 
+	 * // This implementation allows you to specify behavior for any object
+	 * obliterator.Add(TweenService.Create(part, new TweenInfo(1), { Size: Vector3.one }), "Cancel");
+	 * 
+	 * // By passing an index, the object will occupy a namespace
+	 * // If "CurrentTween" already exists, it will call :Remove("CurrentTween") before writing
+	 * obliterator.Add(TweenService.Create(part, new TweenInfo(1), { Size: Vector3.one }), "Destroy", "CurrentTween");
+	 *
 	 * @param object The object you want to clean up.
 	 * @param methodName The name of the method that will be used to clean up. If not passed, it will first check if the object's type exists in TypeDefaults, and if that doesn't exist, it assumes `Destroy`.
 	 * @param index The index that can be used to clean up the object manually.
-	 * @returns The object that was passed.
+	 * @returns The object that was passed as the first argument.
 	 */
 	public Add<
 		O extends keyof U extends never
 			? object
 			: I extends keyof U
-			? U[I]
-			: M extends true
-			? Callback | thread
-			: M extends undefined
-			? RBXScriptConnection | { Destroy(): void }
-			: object,
-		M extends undefined | ((this: O) => void) | ((_: O) => void) | ExtractKeys<O, () => void> | true,
+				? U[I]
+				: M extends true
+					? Callback | thread
+					: M extends undefined
+						? { Destroy(): void } | RBXScriptConnection
+						: object,
+		M extends ((_: O) => void) | ((this: O) => void) | ExtractKeys<O, () => void> | true | undefined,
 		I extends keyof U | undefined = undefined,
 	>(object: O, methodName?: M, index?: I): O;
 
 	/**
-	 * Adds a promise to the janitor. If the janitor is cleaned up and the promise is not completed, the promise will be cancelled.
-	 * @param promise The promise you want to add to the janitor.
-	 * @returns The promise that was passed
+	 * Adds a {@linkcode Promise} to the Janitor. If the Janitor is cleaned up and the
+	 * {@linkcode Promise} is not completed, the {@linkcode Promise} will be cancelled.
+	 * 
+	 * @example
+	 * import { Janitor } from "@rbxts/janitor";
+	 * 
+	 * const obliterator = new Janitor();
+	 * obliterator.AddPromise(Promise.delay(3)).andThenCall(print, "Finished!").catch(warn);
+	 * task.wait(1);
+	 * obliterator.Cleanup();
+	 *
+	 * @param promise The {@linkcode Promise} you want to add to the janitor.
+	 * @param index The index that can be used to clean up the promise manually.
+	 * @returns The {@linkcode promise} that was passed
 	 */
-	public AddPromise<T extends Promise<unknown>>(promise: T): T;
+	public AddPromise<
+		// if you are curious how this works, here's a quick breakdown:
+		// If `U` has no predefined keys (e.g., `U` is `void` or `{}`)
+		// 	- Then `P` can be any Promise
+		// elseif `U` has keys:
+		// 	- If index `I` is one of those keys
+		// 		- Then `P` must be of the type `U[I]` (which implies `U[I]` should be a Promise type)
+		// 		- Else (`I` is undefined or not a key of `U`), `P` can be any Promise
+		P extends keyof U extends never ? Promise<unknown> : I extends keyof U ? U[I] : Promise<unknown>,
+		I extends keyof U | undefined = undefined,
+	>(promise: P, index?: I): P;
 
 	/**
-	 * Constructs an object for you and adds it to the Janitor. It's really just shorthand for `Janitor:Add(Object.new(), MethodName, Index)`.
+	 * Constructs an object for you and adds it to the Janitor. It's really
+	 * just "shorthand" for `janitor.Add(new Object(), methodName, index)`.
+	 *
 	 * @example
-	 * ```ts
 	 * import { Janitor } from "@rbxts/janitor";
 	 *
-	 * const Obliterator = new Janitor();
-	 * const SubObliterator = Obliterator.AddObject(Janitor, "Destroy");
-	 * ```
-	 * @param object The constructable class that you want to cleanup.
+	 * const obliterator = new Janitor();
+	 * const subObliterator = obliterator.AddObject(Janitor, "Destroy");
+	 *
+	 * @param object The constructable class for the object you want to add to the Janitor.
 	 * @param methodName The name of the method that will be used to clean up. If not passed, it will first check if the object's type exists in TypeDefaults, and if that doesn't exist, it assumes `Destroy`.
 	 * @param index The index that can be used to clean up the object manually.
-	 * @param args The arguments used to create the class.
-	 * @returns The new constructed object from the passed `object` class.
+	 * @param parameters The arguments used to create the class.
+	 * @returns The new constructed object from the passed {@linkcode object} class.
 	 */
 	public AddObject<
-			O extends Constructable<unknown>,
-			T extends InstanceType<O>,
-			M extends undefined | ExtractKeys<T, () => void> | true,
-			I extends keyof U | undefined = undefined,
-		>(object: O, methodName?: M, index?: I, ...args: ConstructorParameters<O>): T;
+		O extends Constructable<unknown>,
+		T extends InstanceType<O>,
+		M extends ExtractKeys<T, () => void> | true | undefined,
+		I extends keyof U | undefined = undefined,
+	>(object: O, methodName?: M, index?: I, ...parameters: ConstructorParameters<O>): T;
 
 	/**
-	 * Cleans up whatever `object` was set to this namespace by the 3rd parameter of `.Add()`.
+	 * Cleans up whatever `object` was set to this namespace by the 3rd
+	 * parameter of {@linkcode Janitor.Add}.
+	 * 
+	 * @example
+	 * import { Workspace } from "@rbxts/services";
+	 * import { Janitor } from "@rbxts/janitor";
+	 * 
+	 * const obliterator = new Janitor<{ Baseplate: Part }>();
+	 * obliterator.Add(Workspace.FindFirstChild("Baseplate") as Part, "Destroy", "Baseplate");
+	 * obliterator.Remove("Baseplate");
+	 *
 	 * @param index The index you want to remove.
-	 * @returns The same janitor, for chaining reasons.
+	 * @returns The same {@linkcode Janitor}, for chaining reasons.
 	 */
 	public Remove(index: keyof U): this;
 
 	/**
-	 * Removes an object from the Janitor without running a cleanup.
+	 * Removes an object from the {@linkcode Janitor} without running a cleanup.
 	 *
-	 * ```ts
+	 * @example
 	 * import { Janitor } from "@rbxts/janitor";
 	 *
-	 * const Obliterator = new Janitor<{ Function: () => void }>();
-	 * Obliterator.Add(() => print("Removed!"), true, "Function");
+	 * const obliterator = new Janitor<{ readonly Function: () => void }>();
+	 * obliterator.Add(() => print("Removed!"), true, "Function");
 	 *
-	 * Obliterator.RemoveNoClean("Function"); // Does not print.
-	 * ```
+	 * obliterator.RemoveNoClean("Function"); // Does not print.
+	 *
 	 * @param index The index you are removing.
-	 * @returns The same janitor, for chaining reasons.
+	 * @returns The same {@linkcode Janitor}, for chaining reasons.
 	 */
 	public RemoveNoClean(index: keyof U): this;
 
 	/**
 	 * Cleans up multiple objects at once.
 	 * @param indices The indices you want to remove.
-	 * @returns The same janitor, for chaining reasons.
+	 * @returns The same {@linkcode Janitor}, for chaining reasons.
 	 */
 	public RemoveList(...indices: Array<keyof U>): this;
 
 	/**
 	 * Cleans up multiple objects at once without running their cleanup.
 	 *
-	 * ```ts
+	 * @example
 	 * import { Janitor } from "@rbxts/janitor";
 	 *
 	 * type NoOp = () => void
 	 *
-	 * const Obliterator = new Janitor<{ One: NoOp, Two: NoOp, Three: NoOp }>();
-	 * Obliterator.Add(() => print("Removed One"), true, "One");
-	 * Obliterator.Add(() => print("Removed Two"), true, "Two");
-	 * Obliterator.Add(() => print("Removed Three"), true, "Three");
+	 * const obliterator = new Janitor<{ One: NoOp, Two: NoOp, Three: NoOp }>();
+	 * obliterator.Add(() => print("Removed One"), true, "One");
+	 * obliterator.Add(() => print("Removed Two"), true, "Two");
+	 * obliterator.Add(() => print("Removed Three"), true, "Three");
 	 *
-	 * Obliterator.RemoveListNoClean("One", "Two", "Three"); // Nothing is printed.
-	 * ```
+	 * obliterator.RemoveListNoClean("One", "Two", "Three"); // Nothing is printed.
 	 *
 	 * @param indices The indices you want to remove.
+	 * @returns The same {@linkcode Janitor}, for chaining reasons.
 	 */
 	public RemoveListNoClean(...indices: Array<keyof U>): this;
 
 	/**
-	 * Gets whatever object is stored with the given index, if it exists. This was added since Maid allows getting the task using `__index`.
+	 * Gets whatever object is stored with the given {@linkcode index}, if it exists. This
+	 * was added since Maid allows getting the task using `__index`.
+	 * 
+	 * @example
+	 * import { Workspace } from "@rbxts/services";
+	 * import { Janitor } from "@rbxts/janitor";
+	 * 
+	 * const obliterator = new Janitor<{ Baseplate: Part }>();
+	 * obliterator.Add(Workspace.FindFirstChild("Baseplate") as Part, "Destroy", "Baseplate");
+	 * print(obliterator.Get("Baseplate")); // Returns Baseplate.
+	 *
 	 * @param index The index that the object is stored under.
 	 * @returns This will return the object if it is found, but it won't return anything if it doesn't exist.
 	 */
@@ -133,45 +218,71 @@ export class Janitor<U extends object | void = void> {
 	/**
 	 * Returns a frozen copy of the Janitor's indices.
 	 *
-	 * ```ts
+	 * @example
 	 * import { Workspace } from "@rbxts/services";
 	 * import { Janitor } from "@rbxts/janitor";
 	 *
-	 * const Obliterator = new Janitor<{ Baseplate: Part }>();
-	 * Obliterator.Add(Workspace.FindFirstChild("Baseplate") as Part, "Destroy", "Baseplate");
-	 * print(Obliterator.GetAll().Baseplate); // Prints Baseplate.
-	 * ```
+	 * const obliterator = new Janitor<{ Baseplate: Part }>();
+	 * obliterator.Add(Workspace.FindFirstChild("Baseplate") as Part, "Destroy", "Baseplate");
+	 * print(obliterator.GetAll().Baseplate); // Prints Baseplate.
+	 *
+	 * @returns A frozen object containing all the indices and their corresponding objects.
 	 */
-	public GetAll(): { [P in keyof U]: U[P] | undefined };
+	public GetAll(): { readonly [P in keyof U]: U[P] | undefined };
 
 	/**
-	 * Calls each Object's `MethodName` (or calls the Object if `MethodName === true`) and removes them from the Janitor. Also clears the namespace. This function is also called when you call a Janitor Object (so it can be used as a destructor callback).
+	 * Calls each object's specified `methodName`. If `methodName` is `true`,
+	 * the object itself will be invoked as a function or cancelled if it's a
+	 * thread. Each object is then removed from the Janitor, and the namespace
+	 * is cleared. This method is also invoked when the Janitor instance itself
+	 * is called, allowing it to be used as a destructor callback.
 	 */
 	public Cleanup(): void;
 
 	/**
-	 * Calls `.Cleanup()` and renders the Janitor unusable.
+	 * Calls {@linkcode Janitor.Cleanup} and renders the Janitor unusable. Any
+	 * further calls will throw an error.
 	 */
 	public Destroy(): void;
 
 	/**
-	 * "Links" this Janitor to an Instance, such that the Janitor will `Cleanup` when the Instance is `Destroyed()` and garbage collected.
+	 * "Links" this Janitor to an `Instance`, such that the Janitor will
+	 * {@linkcode Cleanup} when the `Instance` is {@linkcode Instance.Destroy}'d
+	 * and garbage collected.
 	 *
-	 * A Janitor may only be linked to one instance at a time, unless `AllowMultiple` is true.
+	 * A Janitor may only be linked to one instance at a time, unless
+	 * {@linkcode allowMultiple} is `true`.
 	 *
-	 * When called with a truthy `AllowMultiple` parameter, the Janitor will "link" the Instance without overwriting any previous links, and will also not be overwritable.
+	 * When called with a truthy {@linkcode allowMultiple} parameter, the
+	 * Janitor will "link" the Instance without overwriting any previous links,
+	 * and will also not be overridable.
 	 *
-	 * When called with a falsy `AllowMultiple` parameter, the Janitor will overwrite the previous link which was also called with a falsy `AllowMultiple` parameter, if applicable.
-	 * @param object The instance you want to link the Janitor to.
+	 * When called with a falsy {@linkcode allowMultiple} parameter, the Janitor
+	 * will overwrite the previous link which was also called with a falsy
+	 * {@linkcode allowMultiple} parameter, if applicable.
+	 * 
+	 * @example
+	 * import { Janitor } from "@rbxts/janitor";
+	 * 
+	 * const obliterator = new Janitor();
+	 * obliterator.Add(() => print("Cleaning up!"), true);
+	 * 
+	 * {
+	 * 	const folder = new Instance("Folder");
+	 * 	obliterator.LinkToInstance(folder, false);
+	 * 	folder.Destroy();
+	 * }
+	 *
+	 * @param object The {@linkcode Instance} you want to link the Janitor to.
 	 * @param allowMultiple Whether or not to allow multiple links on the same Janitor.
-	 * @returns A pseudo RBXScriptConnection that can be disconnected.
+	 * @returns A {@linkcode RBXScriptConnection} that can be disconnected to prevent the cleanup of {@linkcode Janitor.LinkToInstance}.
 	 */
 	public LinkToInstance(object: Instance, allowMultiple: boolean): RBXScriptConnection;
 
 	/**
 	 * Links several instances to a janitor, which is then returned.
-	 * @param instances All the instances you want linked.
-	 * @returns A janitor that can be used to manually disconnect all LinkToInstances.
+	 * @param instances All the {@linkcode Instance}s you want linked.
+	 * @returns A new {@linkcode Janitor} that can be used to manually disconnect all LinkToInstances.
 	 */
 	public LinkToInstances(...instances: Array<Instance>): Janitor;
 

--- a/janitor/package-lock.json
+++ b/janitor/package-lock.json
@@ -1,31 +1,29 @@
 {
   "name": "@rbxts/janitor",
-  "version": "1.17.0-ts.1",
+  "version": "1.18.3-ts.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rbxts/janitor",
-      "version": "1.17.0-ts.1",
+      "version": "1.18.3-ts.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@rbxts/compiler-types": "^2.2.0-types.0",
-        "@rbxts/types": "^1.0.746"
+        "@rbxts/compiler-types": "^3.0.0-types.0",
+        "@rbxts/types": "^1.0.855"
       }
     },
     "node_modules/@rbxts/compiler-types": {
-      "version": "2.2.0-types.0",
-      "resolved": "https://registry.npmjs.org/@rbxts/compiler-types/-/compiler-types-2.2.0-types.0.tgz",
-      "integrity": "sha512-ycsIGfp49MypbRi4eEPCXTjbb2iLKL1/2GjRrFLuLJL74fCfVtbAXIo2LiZhPrgqIiBLomb4JN5Rcqv4304bzw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "3.0.0-types.0",
+      "resolved": "https://registry.npmjs.org/@rbxts/compiler-types/-/compiler-types-3.0.0-types.0.tgz",
+      "integrity": "sha512-VGOHJPoL7+56NTatMGqQj3K7xWuzEV+aP4QD5vZiHu+bcff3kiTmtoadaF6NkJrmwfFAvbsd4Dg764ZjWNceag==",
+      "dev": true
     },
     "node_modules/@rbxts/types": {
-      "version": "1.0.802",
-      "resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.802.tgz",
-      "integrity": "sha512-w8hoN4qpRzfaJG/YzcAE26M2fIce3TxPNmfLwczKa9aUsZBq8QPhMUr2LO4lT39lN7rt9EffzSrCkc4uqrFCdg==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.0.856",
+      "resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.856.tgz",
+      "integrity": "sha512-Giemet/4JmCi+ROxvY/r7q9T3Ca6Sw5BPdvyOWukZ7hQrkrm5U1CoIJpK7vwS7ieruPGymk0RkwXXB6AAsmOlQ==",
+      "dev": true
     }
   }
 }

--- a/janitor/package.json
+++ b/janitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rbxts/janitor",
-  "version": "1.17.0-ts.1",
+  "version": "1.18.3-ts.0",
   "description": "A port of howmanysmall's janitor module.",
   "main": "src/init.lua",
   "types": "index.d.ts",
@@ -41,8 +41,8 @@
     "access": "public"
   },
   "devDependencies": {
-    "@rbxts/compiler-types": "^2.2.0-types.0",
-    "@rbxts/types": "^1.0.746"
+    "@rbxts/compiler-types": "^3.0.0-types.0",
+    "@rbxts/types": "^1.0.855"
   },
   "volta": {
     "node": "20.11.0"

--- a/janitor/src/FastDefer.luau
+++ b/janitor/src/FastDefer.luau
@@ -1,0 +1,33 @@
+--!native
+--!optimize 2
+--!strict
+
+local FreeThreads: {thread} = table.create(500)
+local function RunFunction<Arguments...>(callback: (Arguments...) -> (), thread: thread, ...: Arguments...)
+	callback(...)
+	table.insert(FreeThreads, thread)
+end
+
+local function Yield()
+	while true do
+		RunFunction(coroutine.yield())
+	end
+end
+
+local function FastDefer<Arguments...>(callback: (Arguments...) -> (), ...: Arguments...): thread
+	local thread: thread
+	local freeAmount = #FreeThreads
+
+	if freeAmount > 0 then
+		thread = FreeThreads[freeAmount]
+		FreeThreads[freeAmount] = nil
+	else
+		thread = coroutine.create(Yield)
+		coroutine.resume(thread)
+	end
+
+	-- TODO: This might be able to throw?
+	return task.defer(thread, callback, thread, ...)
+end
+
+return FastDefer

--- a/janitor/src/Promise.luau
+++ b/janitor/src/Promise.luau
@@ -1,7 +1,7 @@
+--!optimize 2
 --!strict
 -- Partial types for Promise
 
-local Packages = script.Parent.Parent
 -- monkey patched by OverHash for roblox-ts support
 -- roblox-ts exposes the TS runtime lib through _G[script]
 -- which exposes the Promise library
@@ -26,21 +26,18 @@ type ErrorOptions = {
 	kind: ErrorKind,
 }
 
-export type Error = typeof(setmetatable(
-	{} :: ErrorStaticAndShared & {
-		error: string,
-		trace: string?,
-		context: string?,
-		kind: ErrorKind,
-		parent: Error?,
-		createdTick: number,
-		createdTrace: string,
+export type Error = typeof(setmetatable({} :: ErrorStaticAndShared & {
+	error: string,
+	trace: string?,
+	context: string?,
+	kind: ErrorKind,
+	parent: Error?,
+	createdTick: number,
+	createdTrace: string,
 
-		extend: (self: Error, options: ErrorOptions?) -> Error,
-		getErrorChain: (self: Error) -> { Error },
-	},
-	{} :: { __tostring: (self: Error) -> string }
-))
+	extend: (self: Error, options: ErrorOptions?) -> Error,
+	getErrorChain: (self: Error) -> {Error},
+}, {} :: {__tostring: (self: Error) -> string}))
 type ErrorStatic = ErrorStaticAndShared & {
 	new: (options: ErrorOptions?, parent: Error?) -> Error,
 	is: (anything: any) -> boolean,
@@ -111,9 +108,9 @@ export type PromiseStatic = {
 		Cancelled: "Cancelled",
 	},
 
-	all: <T>(promises: { TypedPromise<T> }) -> TypedPromise<{ T }>,
-	allSettled: <T>(promise: { TypedPromise<T> }) -> TypedPromise<{ Status }>,
-	any: <T>(promise: { TypedPromise<T> }) -> TypedPromise<T>,
+	all: <T>(promises: {TypedPromise<T>}) -> TypedPromise<{T}>,
+	allSettled: <T>(promise: {TypedPromise<T>}) -> TypedPromise<{Status}>,
+	any: <T>(promise: {TypedPromise<T>}) -> TypedPromise<T>,
 	defer: <TReturn...>(
 		executor: (
 			resolve: (TReturn...) -> (),
@@ -123,11 +120,11 @@ export type PromiseStatic = {
 	) -> TypedPromise<TReturn...>,
 	delay: (seconds: number) -> TypedPromise<number>,
 	each: <T, TReturn>(
-		list: { T | TypedPromise<T> },
+		list: {T | TypedPromise<T>},
 		predicate: (value: T, index: number) -> TReturn | TypedPromise<TReturn>
-	) -> TypedPromise<{ TReturn }>,
+	) -> TypedPromise<{TReturn}>,
 	fold: <T, TReturn>(
-		list: { T | TypedPromise<T> },
+		list: {T | TypedPromise<T>},
 		reducer: (accumulator: TReturn, value: T, index: number) -> TReturn | TypedPromise<TReturn>
 	) -> TypedPromise<TReturn>,
 	fromEvent: <TReturn...>(
@@ -144,7 +141,7 @@ export type PromiseStatic = {
 	) -> TypedPromise<TReturn...>,
 	onUnhandledRejection: (callback: (promise: TypedPromise<any>, ...any) -> ()) -> () -> (),
 	promisify: <TArgs..., TReturn...>(callback: (TArgs...) -> TReturn...) -> (TArgs...) -> TypedPromise<TReturn...>,
-	race: <T>(promises: { TypedPromise<T> }) -> TypedPromise<T>,
+	race: <T>(promises: {TypedPromise<T>}) -> TypedPromise<T>,
 	reject: (...any) -> TypedPromise<...any>,
 	resolve: <TReturn...>(TReturn...) -> TypedPromise<TReturn...>,
 	retry: <TArgs..., TReturn...>(
@@ -158,7 +155,7 @@ export type PromiseStatic = {
 		seconds: number,
 		TArgs...
 	) -> TypedPromise<TReturn...>,
-	some: <T>(promise: { TypedPromise<T> }, count: number) -> TypedPromise<{ T }>,
+	some: <T>(promise: {TypedPromise<T>}, count: number) -> TypedPromise<{T}>,
 	try: <TArgs..., TReturn...>(callback: (TArgs...) -> TReturn..., TArgs...) -> TypedPromise<TReturn...>,
 }
 

--- a/janitor/src/init.luau
+++ b/janitor/src/init.luau
@@ -9,6 +9,7 @@
 -- LinkToInstance fixed by Elttob.
 -- Cleanup edge cases fixed by codesenseAye.
 
+local FastDefer = require(script.FastDefer)
 local Promise = require(script.Promise)
 type Promise<T...> = Promise.TypedPromise<T...>
 
@@ -23,77 +24,75 @@ local INVALID_METHOD_NAME =
 local METHOD_NOT_FOUND_ERROR = "Object %* doesn't have method %*, are you sure you want to add it? Traceback: %*"
 local NOT_A_PROMISE = "Invalid argument #1 to 'Janitor:AddPromise' (Promise expected, got %* (%*)) Traceback: %*"
 
-export type Janitor = typeof(setmetatable(
-	{} :: {
-		CurrentlyCleaning: boolean,
-		SuppressInstanceReDestroy: boolean,
-
-		Add: <T>(self: Janitor, object: T, methodName: BooleanOrString?, index: any?) -> T,
-		AddObject: <T, A...>(
-			self: Janitor,
-			constructor: {new: (A...) -> T},
-			methodName: BooleanOrString?,
-			index: any?,
-			A...
-		) -> T,
-		AddPromise: <T...>(self: Janitor, promiseObject: Promise<T...>) -> Promise<T...>,
-
-		Remove: (self: Janitor, index: any) -> Janitor,
-		RemoveNoClean: (self: Janitor, index: any) -> Janitor,
-
-		RemoveList: (self: Janitor, ...any) -> Janitor,
-		RemoveListNoClean: (self: Janitor, ...any) -> Janitor,
-
-		Get: (self: Janitor, index: any) -> any?,
-		GetAll: (self: Janitor) -> {[any]: any},
-
-		Cleanup: (self: Janitor) -> (),
-		Destroy: (self: Janitor) -> (),
-
-		LinkToInstance: (self: Janitor, Object: Instance, allowMultiple: boolean?) -> RBXScriptConnection,
-		LinkToInstances: (self: Janitor, ...Instance) -> Janitor,
-	},
-	{} :: {__call: (self: Janitor) -> ()}
-))
-type Private = typeof(setmetatable(
-	{} :: {
-		CurrentlyCleaning: boolean,
-		SuppressInstanceReDestroy: boolean,
-
-		-- Private
-		[any]: BooleanOrString,
-
-		Add: <T>(self: Private, object: T, methodName: BooleanOrString?, index: any?) -> T,
-		AddObject: <T, A...>(
-			self: Private,
-			constructor: {new: (A...) -> T},
-			methodName: BooleanOrString?,
-			index: any?,
-			A...
-		) -> T,
-		AddPromise: <T...>(self: Private, promiseObject: Promise<T...>) -> Promise<T...>,
-
-		Remove: (self: Private, index: any) -> Private,
-		RemoveNoClean: (self: Private, index: any) -> Private,
-
-		RemoveList: (self: Private, ...any) -> Private,
-		RemoveListNoClean: (self: Private, ...any) -> Private,
-
-		Get: (self: Private, index: any) -> any?,
-		GetAll: (self: Private) -> {[any]: any},
-
-		Cleanup: (self: Private) -> (),
-		Destroy: (self: Private) -> (),
-
-		LinkToInstance: (self: Private, object: Instance, allowMultiple: boolean?) -> RBXScriptConnection,
-		LinkToInstances: (self: Private, ...Instance) -> Private,
-	},
-	{} :: {__call: (self: Private) -> ()}
-))
-type Static = {
-	ClassName: "Janitor",
+export type Janitor = typeof(setmetatable({} :: {
 	CurrentlyCleaning: boolean,
 	SuppressInstanceReDestroy: boolean,
+	UnsafeThreadCleanup: boolean,
+
+	Add: <T>(self: Janitor, object: T, methodName: BooleanOrString?, index: any?) -> T,
+	AddObject: <T, A...>(
+		self: Janitor,
+		constructor: {new: (A...) -> T},
+		methodName: BooleanOrString?,
+		index: any?,
+		A...
+	) -> T,
+	AddPromise: <T...>(self: Janitor, promiseObject: Promise<T...>, index: unknown?) -> Promise<T...>,
+
+	Remove: (self: Janitor, index: any) -> Janitor,
+	RemoveNoClean: (self: Janitor, index: any) -> Janitor,
+
+	RemoveList: (self: Janitor, ...any) -> Janitor,
+	RemoveListNoClean: (self: Janitor, ...any) -> Janitor,
+
+	Get: (self: Janitor, index: any) -> any?,
+	GetAll: (self: Janitor) -> {[any]: any},
+
+	Cleanup: (self: Janitor) -> (),
+	Destroy: (self: Janitor) -> (),
+
+	LinkToInstance: (self: Janitor, Object: Instance, allowMultiple: boolean?) -> RBXScriptConnection,
+	LinkToInstances: (self: Janitor, ...Instance) -> Janitor,
+}, {} :: {__call: (self: Janitor) -> ()}))
+type Private = typeof(setmetatable({} :: {
+	CurrentlyCleaning: boolean,
+	SuppressInstanceReDestroy: boolean,
+	UnsafeThreadCleanup: boolean,
+
+	-- Private
+	[any]: BooleanOrString,
+
+	Add: <T>(self: Private, object: T, methodName: BooleanOrString?, index: any?) -> T,
+	AddObject: <T, A...>(
+		self: Private,
+		constructor: {new: (A...) -> T},
+		methodName: BooleanOrString?,
+		index: any?,
+		A...
+	) -> T,
+	AddPromise: <T...>(self: Private, promiseObject: Promise<T...>, index: unknown?) -> Promise<T...>,
+
+	Remove: (self: Private, index: any) -> Private,
+	RemoveNoClean: (self: Private, index: any) -> Private,
+
+	RemoveList: (self: Private, ...any) -> Private,
+	RemoveListNoClean: (self: Private, ...any) -> Private,
+
+	Get: (self: Private, index: any) -> any?,
+	GetAll: (self: Private) -> {[any]: any},
+
+	Cleanup: (self: Private) -> (),
+	Destroy: (self: Private) -> (),
+
+	LinkToInstance: (self: Private, object: Instance, allowMultiple: boolean?) -> RBXScriptConnection,
+	LinkToInstances: (self: Private, ...Instance) -> Private,
+}, {} :: {__call: (self: Private) -> ()}))
+type Static = {
+	ClassName: "Janitor",
+
+	CurrentlyCleaning: boolean,
+	SuppressInstanceReDestroy: boolean,
+	UnsafeThreadCleanup: boolean,
 
 	new: () -> Janitor,
 	Is: (object: any) -> boolean,
@@ -105,9 +104,14 @@ type PrivateStatic = Static & {
 }
 
 --[=[
-	Janitor is a light-weight, flexible object for cleaning up connections, instances, or anything. This implementation covers all use cases,
-	as it doesn't force you to rely on naive typechecking to guess how an instance should be cleaned up.
-	Instead, the developer may specify any behavior for any object.
+	Janitor is a light-weight, flexible object for cleaning up connections,
+	instances, or anything. This implementation covers all use cases, as it
+	doesn't force you to rely on naive typechecking to guess how an instance
+	should be cleaned up. Instead, the developer may specify any behavior for
+	any object.
+
+	This is the fastest OOP library on Roblox of its kind on both X86-64 as
+	well as ARM64.
 
 	@class Janitor
 ]=]
@@ -115,10 +119,11 @@ local Janitor = {} :: Janitor & Static
 local Private = Janitor :: Private & PrivateStatic
 Janitor.ClassName = "Janitor"
 Janitor.CurrentlyCleaning = true
-Janitor.SuppressInstanceReDestroy = false;
+Janitor.SuppressInstanceReDestroy = false
+Janitor.UnsafeThreadCleanup = false;
 (Janitor :: any).__index = Janitor
 
-local Janitors = setmetatable({} :: {[Private]: {[any]: any}}, {__mode = "k"})
+local Janitors = setmetatable({} :: {[Private]: {[any]: any}}, {__mode = "ks"})
 
 --[=[
 	Whether or not the Janitor is currently cleaning up.
@@ -126,14 +131,21 @@ local Janitors = setmetatable({} :: {[Private]: {[any]: any}}, {__mode = "k"})
 	@prop CurrentlyCleaning boolean
 	@within Janitor
 ]=]
-
 --[=[
-	Whether or not you want to suppress the re-destroying
-	of instances. Default is false, which is the original
-	behavior.
+	Whether or not you want to suppress the re-destroying of instances. Default
+	is false, which is the original behavior.
 
 	@since 1.15.4
 	@prop SuppressInstanceReDestroy boolean
+	@within Janitor
+]=]
+--[=[
+	Whether or not to use the unsafe fast defer function for cleaning up
+	threads. This might be able to throw, so be careful. If you're getting any
+	thread related errors, chances are it is this.
+
+	@since 1.18.0
+	@prop UnsafeThreadCleanup boolean
 	@within Janitor
 ]=]
 
@@ -175,8 +187,10 @@ end
 ]=]
 Janitor.instanceof = Janitor.Is
 
+local Destroy = game.Destroy
+
 -- very cheeky optimization
-local function Remove(self: Private, index: any)
+local function Remove(self: Private, index: any): Janitor
 	local this = Janitors[self]
 
 	if this then
@@ -191,7 +205,7 @@ local function Remove(self: Private, index: any)
 				if type(object) == "function" then
 					object()
 				else
-					local wasCancelled: boolean = nil
+					local wasCancelled: boolean? = nil
 					if coroutine.running() ~= object then
 						wasCancelled = pcall(function()
 							task.cancel(object)
@@ -200,17 +214,35 @@ local function Remove(self: Private, index: any)
 
 					if not wasCancelled then
 						local toCleanup = object
-						task.defer(function()
-							task.cancel(toCleanup)
-						end)
+						if self.UnsafeThreadCleanup then
+							FastDefer(function()
+								task.cancel(toCleanup)
+							end)
+						else
+							task.defer(function()
+								task.cancel(toCleanup)
+							end)
+						end
 					end
 				end
 			else
-				local objectMethod = object[methodName]
-				if objectMethod then
-					if self.SuppressInstanceReDestroy and methodName == "Destroy" and typeof(object) == "Instance" then
-						pcall(objectMethod, object)
+				if methodName == "Destroy" then
+					if self.SuppressInstanceReDestroy and typeof(object) == "Instance" then
+						pcall(Destroy, object)
 					else
+						local destroy = object.Destroy
+						if destroy then
+							destroy(object)
+						end
+					end
+				elseif methodName == "Disconnect" then
+					local disconnect = object.Disconnect
+					if disconnect then
+						disconnect(object)
+					end
+				else
+					local objectMethod = (object :: never)[methodName] :: (object: unknown) -> ()
+					if objectMethod then
 						objectMethod(object)
 					end
 				end
@@ -384,6 +416,42 @@ function Janitor:AddObject<T, A...>(constructor: {new: (A...) -> T}, methodName:
 	return Add(self, constructor.new(...), methodName, index)
 end
 
+local function Get(self: Private, index: unknown): any?
+	local this = Janitors[self]
+	return if this then this[index] else nil
+end
+
+--[=[
+	Gets whatever object is stored with the given index, if it exists. This was
+	added since Maid allows getting the task using `__index`.
+
+	### Luau:
+
+	```lua
+	local obliterator = Janitor.new()
+	obliterator:Add(Workspace.Baseplate, "Destroy", "Baseplate")
+	print(obliterator:Get("Baseplate")) -- Returns Baseplate.
+	```
+
+	### TypeScript:
+
+	```ts
+	import { Workspace } from "@rbxts/services";
+	import { Janitor } from "@rbxts/janitor";
+
+	const obliterator = new Janitor<{ Baseplate: Part }>();
+	obliterator.Add(Workspace.FindFirstChild("Baseplate") as Part, "Destroy", "Baseplate");
+	print(obliterator.Get("Baseplate")); // Returns Baseplate.
+	```
+
+	@method Get
+	@within Janitor
+
+	@param index unknown -- The index that the object is stored under.
+	@return unknown? -- This will return the object if it is found, but it won't return anything if it doesn't exist.
+]=]
+Janitor.Get = Get
+
 --[=[
 	Adds a [Promise](https://github.com/evaera/roblox-lua-promise) to the
 	Janitor. If the Janitor is cleaned up and the Promise is not completed, the
@@ -412,9 +480,10 @@ end
 	@error NotAPromiseError -- Thrown if the promise is not a Promise.
 
 	@param promiseObject Promise -- The promise you want to add to the Janitor.
+	@param index? unknown -- The index that can be used to clean up the object manually.
 	@return Promise
 ]=]
-function Janitor:AddPromise<T...>(promiseObject: Promise<T...>): Promise<T...>
+function Janitor:AddPromise<T...>(promiseObject: Promise<T...>, index: unknown?): Promise<T...>
 	if not Promise then
 		return promiseObject
 	end
@@ -423,26 +492,32 @@ function Janitor:AddPromise<T...>(promiseObject: Promise<T...>): Promise<T...>
 		error(string.format(NOT_A_PROMISE, typeof(promiseObject), tostring(promiseObject), debug.traceback(nil, 2)))
 	end
 
-	if promiseObject:getStatus() == Promise.Status.Started then
-		local uniqueId = newproxy(false)
-		local newPromise = Add(self, Promise.new(function(resolve, _, onCancel)
-			if onCancel(function()
-				promiseObject:cancel()
-			end) then
-				return
-			end
-
-			resolve(promiseObject)
-		end), "cancel", uniqueId)
-
-		newPromise:finally(function()
-			Remove(self, uniqueId)
-		end)
-
-		return newPromise :: never
+	if promiseObject:getStatus() ~= Promise.Status.Started then
+		return promiseObject
 	end
 
-	return promiseObject
+	local uniqueId = index
+	if uniqueId == nil then
+		uniqueId = newproxy(false)
+	end
+
+	local newPromise = Add(self, Promise.new(function(resolve, _, onCancel)
+		if onCancel(function()
+			promiseObject:cancel()
+		end) then
+			return
+		end
+
+		resolve(promiseObject)
+	end), "cancel", uniqueId)
+
+	newPromise:finally(function()
+		if Get(self, uniqueId) == newPromise then
+			Remove(self, uniqueId)
+		end
+	end)
+
+	return newPromise :: never
 end
 
 --[=[
@@ -507,7 +582,7 @@ Private.Remove = Remove
 	@param index unknown -- The index you are removing.
 	@return Janitor
 ]=]
-function Private:RemoveNoClean(index: any)
+function Private:RemoveNoClean(index: any): Janitor
 	local this = Janitors[self]
 
 	if this then
@@ -562,7 +637,7 @@ end
 	@param ... unknown -- The indices you want to remove.
 	@return Janitor
 ]=]
-function Janitor:RemoveList(...: any)
+function Janitor:RemoveList(...: any): Janitor
 	local this = Janitors[self]
 	if this then
 		local length = select("#", ...)
@@ -633,7 +708,7 @@ end
 	@param ... unknown -- The indices you want to remove.
 	@return Janitor
 ]=]
-function Janitor:RemoveListNoClean(...: any)
+function Janitor:RemoveListNoClean(...: any): Janitor
 	local this = Janitors[self]
 	if this then
 		local length = select("#", ...)
@@ -681,7 +756,6 @@ function Janitor:RemoveListNoClean(...: any)
 		end
 
 		for selectIndex = 1, length do
-			-- MACRO
 			local index = select(selectIndex, ...)
 			local object = this[index]
 			if object then
@@ -692,37 +766,6 @@ function Janitor:RemoveListNoClean(...: any)
 	end
 
 	return self
-end
-
---[=[
-	Gets whatever object is stored with the given index, if it exists. This was
-	added since Maid allows getting the task using `__index`.
-
-	### Luau:
-
-	```lua
-	local obliterator = Janitor.new()
-	obliterator:Add(Workspace.Baseplate, "Destroy", "Baseplate")
-	print(obliterator:Get("Baseplate")) -- Returns Baseplate.
-	```
-
-	### TypeScript:
-
-	```ts
-	import { Workspace } from "@rbxts/services";
-	import { Janitor } from "@rbxts/janitor";
-
-	const obliterator = new Janitor<{ Baseplate: Part }>();
-	obliterator.Add(Workspace.FindFirstChild("Baseplate") as Part, "Destroy", "Baseplate");
-	print(obliterator.Get("Baseplate")); // Returns Baseplate.
-	```
-
-	@param index unknown -- The index that the object is stored under.
-	@return unknown? -- This will return the object if it is found, but it won't return anything if it doesn't exist.
-]=]
-function Janitor:Get(index: any): any?
-	local this = Janitors[self]
-	return if this then this[index] else nil
 end
 
 --[=[
@@ -755,67 +798,6 @@ function Janitor:GetAll(): {[any]: any}
 	return if this then table.freeze(table.clone(this)) else {}
 end
 
-local function GetFenv(self: Private): () -> (any, BooleanOrString)
-	return function(): ()
-		for object, methodName in next, self do
-			if object ~= "SuppressInstanceReDestroy" then
-				return object, methodName
-			end
-		end
-	end :: never
-end
-
-local function Cleanup(self: Private)
-	if not self.CurrentlyCleaning then
-		self.CurrentlyCleaning = nil :: never
-
-		local get = GetFenv(self)
-		local object, methodName = get()
-
-		while object and methodName do -- changed to a while loop so that if you add to the janitor inside of a callback it doesn't get untracked (instead it will loop continuously which is a lot better than a hard to pindown edgecase)
-			if methodName == true then
-				if type(object) == "function" then
-					object()
-				elseif type(object) == "thread" then
-					local wasCancelled: boolean = nil
-					if coroutine.running() ~= object then
-						wasCancelled = pcall(function()
-							task.cancel(object)
-						end)
-					end
-
-					if not wasCancelled then
-						local toCleanup = object
-						task.defer(function()
-							task.cancel(toCleanup)
-						end)
-					end
-				end
-			else
-				local objectMethod = (object :: never)[methodName] :: (object: unknown) -> ()
-				if objectMethod then
-					if self.SuppressInstanceReDestroy and methodName == "Destroy" and typeof(object) == "Instance" then
-						pcall(objectMethod, object)
-					else
-						objectMethod(object)
-					end
-				end
-			end
-
-			self[object] = nil
-			object, methodName = get()
-		end
-
-		local this = Janitors[self]
-		if this then
-			table.clear(this)
-			Janitors[self] = nil
-		end
-
-		self.CurrentlyCleaning = false
-	end
-end
-
 --[=[
 	Calls each object's `methodName` (or calls the object if
 	`methodName == true`) and removes them from the Janitor. Also clears the
@@ -839,6 +821,79 @@ end
 	@method Cleanup
 	@within Janitor
 ]=]
+local function Cleanup(self: Private): ()
+	if not self.CurrentlyCleaning then
+		local suppressInstanceReDestroy = self.SuppressInstanceReDestroy
+		local unsafeThreadCleanup = self.UnsafeThreadCleanup
+
+		self.CurrentlyCleaning = nil :: never
+		self.SuppressInstanceReDestroy = nil :: never
+		self.UnsafeThreadCleanup = nil :: never
+
+		local object, methodName = next(self)
+		while object and methodName do
+			if methodName == true then
+				if type(object) == "function" then
+					object()
+				else
+					local wasCancelled: boolean? = nil
+					if coroutine.running() ~= object then
+						wasCancelled = pcall(function()
+							task.cancel(object)
+						end)
+					end
+
+					if not wasCancelled then
+						local toCleanup = object
+						if unsafeThreadCleanup then
+							FastDefer(function()
+								task.cancel(toCleanup)
+							end)
+						else
+							task.defer(function()
+								task.cancel(toCleanup)
+							end)
+						end
+					end
+				end
+			else
+				if methodName == "Destroy" then
+					if self.SuppressInstanceReDestroy and typeof(object) == "Instance" then
+						pcall(Destroy, object)
+					else
+						local destroy = object.Destroy
+						if destroy then
+							destroy(object)
+						end
+					end
+				elseif methodName == "Disconnect" then
+					local disconnect = object.Disconnect
+					if disconnect then
+						disconnect(object)
+					end
+				else
+					local objectMethod = (object :: never)[methodName] :: (object: unknown) -> ()
+					if objectMethod then
+						objectMethod(object)
+					end
+				end
+			end
+
+			self[object] = nil
+			object, methodName = next(self, object)
+		end
+
+		local this = Janitors[self]
+		if this then
+			table.clear(this)
+			Janitors[self] = nil
+		end
+
+		self.CurrentlyCleaning = false
+		self.SuppressInstanceReDestroy = suppressInstanceReDestroy
+		self.UnsafeThreadCleanup = unsafeThreadCleanup
+	end
+end
 Private.Cleanup = Cleanup
 
 --[=[
@@ -849,7 +904,7 @@ Private.Cleanup = Cleanup
 	error.
 	:::
 ]=]
-function Janitor:Destroy()
+function Janitor:Destroy(): ()
 	Cleanup(self)
 	table.clear(self :: never)
 	setmetatable(self :: any, nil)
@@ -923,7 +978,7 @@ Private.LinkToInstance = LinkToInstance;
 	@param ... Instance -- All the Instances you want linked.
 	@return Janitor -- A new Janitor that can be used to manually disconnect all LinkToInstances.
 ]=]
-function Janitor:LinkToInstances(...: Instance)
+function Janitor:LinkToInstances(...: Instance): Janitor
 	local manualCleanup = Janitor.new()
 	for index = 1, select("#", ...) do
 		local object = select(index, ...)
@@ -942,5 +997,5 @@ function Private:__tostring()
 end
 
 return table.freeze({
-	Janitor = Janitor :: Static
+	Janitor = Janitor :: Static;
 })


### PR DESCRIPTION
# Janitor 1.18.3 Update

Basically just updates to [Janitor v1.18.3](https://github.com/howmanysmall/Janitor/blob/main/changelog.md#1183---2025-03-13).

## (Relevant) Changelog

### Added

- Added unique index support to `Janitor.AddPromise`.
- Literally doubled performance. This is not a joke, it is twice as fast and is also the fastest on every CPU architecture.
- Added the `UnsafeThreadCleanup` feature.

### Changed

- Changed how `Janitor.Cleanup`'s loop is handled. We are not using the `GetFenv` function anymore.
- Cleaning up should be faster. Compared to Duster with the UltraJanitor modification, it is within 3%.
- Changed the `Janitors` weak metatable slightly.
- Changed some documentation to be a bit better.
- Changed the `*.lua` files to `*.luau`.

### Fixed

- Fixed a typo with `SuppressInstanceReDestroy` (was `SupressInstanceReDestroy`).
